### PR TITLE
Thêm CI kiểm thử và build tự động

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run db:generate
+
+      - name: Run API tests
+        run: npm test
+
+      - name: Build API and web
+        run: npm run build


### PR DESCRIPTION
## Nội dung

- Thêm GitHub Actions CI cho Pull Request, nhánh `main` và chạy thủ công.
- Cài dependency bằng `npm ci`, sinh Prisma Client, chạy toàn bộ API test và build API/Web.
- Giới hạn quyền workflow ở mức chỉ đọc và tự hủy lượt chạy cũ khi có commit mới.

## Lý do

Repository chưa có kiểm tra tự động trước khi merge. Workflow này tạo hàng rào chất lượng tối thiểu và là nền tảng để bổ sung CD khi có máy chủ production hỗ trợ SSH, Docker và PostgreSQL.

CD chưa được thêm trong PR này vì tài khoản DirectAdmin hiện tại không có SSH/Node.js/PostgreSQL và tên miền chưa hoạt động công khai. Không lưu thông tin hosting hoặc secret trong repository.

## Kiểm tra

- `npm run db:generate` — đạt.
- `npm test` — 76/76 đạt.
- `npm run build` — API và Web build thành công.
- `git diff --check` — đạt.
